### PR TITLE
Add collectd graphs

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,17 @@
 Release History
 ---------------
 
+0.0.12 (2015-01-22)
++++++++++++++++++++
+
+**Improvements**
+
+- Add client method to create all supported collectd plugin graphs for a
+  specific target at once.
+- Update ``circonus.collectd.cpu`` API to act like the other plugin modules.
+- Change exception handling to raise HTTPError in log decorator.
+- Add API documentation
+
 0.0.11 (2015-01-21)
 +++++++++++++++++++
 

--- a/circonus/__init__.py
+++ b/circonus/__init__.py
@@ -1,5 +1,5 @@
 __title__ = "circonus"
-__version__ = "0.0.11"
+__version__ = "0.0.12"
 
 from logging import NullHandler
 

--- a/circonus/annotation.py
+++ b/circonus/annotation.py
@@ -84,5 +84,4 @@ class Annotation(object):
             "rel_metrics": self.rel_metrics
         }
         self.response = self.client.create(self.RESOURCE_PATH, data)
-        self.response.raise_for_status()
         return self

--- a/circonus/client.py
+++ b/circonus/client.py
@@ -16,6 +16,7 @@ import json
 from circonus.annotation import Annotation
 from circonus.collectd.cpu import get_cpu_graph_data
 from circonus.collectd.df import get_df_graph_data
+from circonus.collectd.graph import get_collectd_graph_data
 from circonus.collectd.memory import get_memory_graph_data
 from circonus.collectd.interface import get_interface_graph_data
 from circonus.tag import get_tags_with, get_telemetry_tag, is_taggable
@@ -297,3 +298,63 @@ class CirconusClient(object):
         check_bundle = r.json()[0]
         data = get_df_graph_data(check_bundle, mount_dir)
         return self.create("graph", data) if data else None
+
+    def get_collectd_check_bundle(self, target):
+        """Get a ``collectd`` check bundle for ``target``.
+
+        :param str target: The target to filter the check bundle.
+        :rtype: :py:class:`dict`
+
+        The *first* ``collectd`` check bundle for ``target`` will be returned.  A given ``target`` should not have
+        more than one ``collectd`` check bundle at any given moment.
+
+        """
+        r = self.get("check_bundle", {"f_target": target, "f_type": "collectd"})
+        r.raise_for_status()
+        check_bundle = r.json()[0]
+        return check_bundle
+
+    def create_collectd_graphs(self, target, interface_names=None, mount_dirs=None):
+        """Create several graphs from a ``collectd`` check bundle.
+
+        :param str target: The target of the check bundle to filter for.
+        :param list interface_name: (optional) The interface names to create ``interface`` graphs for, e.g., ``["eth0"]``.
+        :param list mount_dirs: (optional) The mount directories to create ``df`` graphs for, e.g., ``["/root", "/mnt"]``.
+        :rtype: (:py:class:`bool`, :py:class:`list`)
+
+        ``target`` is used to filter ``collectd`` check bundles.
+
+        Only the first ``collectd`` check bundle will be used as no ``target`` should have more than a single
+        ``collectd`` check bundle at once.
+
+        ``mount_dirs`` should be a :py:class:`list` of directories where devices are mounted.  ``df`` graphs will be
+        created for each.
+
+        ``interface_names`` should be a :py:class:`list` of network interface device names.  ``interface`` graphs will
+        be created for each.
+
+        Return :py:const:`True` if all ``collectd`` graphs were created successfully, :py:const:`False` otherwise,
+        along with a :py:class:`list` of :class:`requests.Response` instances for requests made.
+
+        """
+        if mount_dirs is None:
+            mount_dirs = ["root"]
+
+        if interface_names is None:
+            interface_names = ["eth0"]
+
+        success = False
+        responses = []
+
+        try:
+            check_bundle = self.get_collectd_check_bundle(target)
+            graph_data = get_collectd_graph_data(check_bundle, interface_names, mount_dirs)
+            for d in graph_data:
+                r = self.create("graph", d)
+                r.raise_for_status()
+                responses.append(r)
+            success = True
+        except Exception as e:
+            log.error("collectd graphs could not be created: %s", e)
+
+        return success, responses

--- a/circonus/client.py
+++ b/circonus/client.py
@@ -232,16 +232,18 @@ class CirconusClient(object):
         """Create a CPU graph from a ``collectd`` check bundle for ``target``.
 
         :param str target: The target of the check bundle to filter for.
-        :rtype: :class:`requests.Response`
+        :rtype: :class:`requests.Response` or :py:const:`None`
 
         ``target`` is used to filter ``collectd`` check bundles.
+
+        :py:const:`None` is returned if no data to create the graph could be found for ``target``.
 
         """
         r = self.get("check_bundle", {"f_target": target, "f_type": "collectd"})
         r.raise_for_status()
         check_bundle = r.json()[0]
         data = get_cpu_graph_data(check_bundle)
-        return self.create("graph", data)
+        return self.create("graph", data) if data else None
 
     def create_collectd_memory_graph(self, target):
         """Create a memory graph from a ``collectd`` check bundle for ``target``.

--- a/circonus/client.py
+++ b/circonus/client.py
@@ -340,18 +340,13 @@ class CirconusClient(object):
         if interface_names is None:
             interface_names = ["eth0"]
 
-        successes = []
         responses = []
-
         try:
             check_bundle = self.get_collectd_check_bundle(target)
             graph_data = get_collectd_graph_data(check_bundle, interface_names, mount_dirs)
             for d in graph_data:
-                r = self.create("graph", d)
-                successes.append(status_codes.OK == r.status_code)
-                responses.append(r)
+                responses.append(self.create("graph", d))
         except HTTPError as e:
-            successes.append(False)
             log.error("collectd graphs could not be created: %s", e)
 
-        return all(successes), responses
+        return responses and all([status_codes.OK == r.status_code for r in responses]), responses

--- a/circonus/client.py
+++ b/circonus/client.py
@@ -229,6 +229,21 @@ class CirconusClient(object):
         a.create()
         return a
 
+    def get_collectd_check_bundle(self, target):
+        """Get a ``collectd`` check bundle for ``target``.
+
+        :param str target: The target to filter the check bundle.
+        :rtype: :py:class:`dict`
+
+        The *first* ``collectd`` check bundle for ``target`` will be returned.  A given ``target`` should not have
+        more than one ``collectd`` check bundle at any given moment.
+
+        """
+        r = self.get("check_bundle", {"f_target": target, "f_type": "collectd"})
+        r.raise_for_status()
+        check_bundle = r.json()[0]
+        return check_bundle
+
     def create_collectd_cpu_graph(self, target):
         """Create a CPU graph from a ``collectd`` check bundle for ``target``.
 
@@ -240,9 +255,7 @@ class CirconusClient(object):
         :py:const:`None` is returned if no data to create the graph could be found for ``target``.
 
         """
-        r = self.get("check_bundle", {"f_target": target, "f_type": "collectd"})
-        r.raise_for_status()
-        check_bundle = r.json()[0]
+        check_bundle = self.get_collectd_check_bundle(target)
         data = get_cpu_graph_data(check_bundle)
         return self.create("graph", data) if data else None
 
@@ -257,9 +270,7 @@ class CirconusClient(object):
         :py:const:`None` is returned if no data to create the graph could be found for ``target``.
 
         """
-        r = self.get("check_bundle", {"f_target": target, "f_type": "collectd"})
-        r.raise_for_status()
-        check_bundle = r.json()[0]
+        check_bundle = self.get_collectd_check_bundle(target)
         data = get_memory_graph_data(check_bundle)
         return self.create("graph", data) if data else None
 
@@ -275,9 +286,7 @@ class CirconusClient(object):
         :py:const:`None` is returned if no data to create the graph could be found for ``target``.
 
         """
-        r = self.get("check_bundle", {"f_target": target, "f_type": "collectd"})
-        r.raise_for_status()
-        check_bundle = r.json()[0]
+        check_bundle = self.get_collectd_check_bundle(target)
         data = get_interface_graph_data(check_bundle, interface_name)
         return self.create("graph", data) if data else None
 
@@ -293,26 +302,9 @@ class CirconusClient(object):
         :py:const:`None` is returned if no data to create the graph could be found for ``target``.
 
         """
-        r = self.get("check_bundle", {"f_target": target, "f_type": "collectd"})
-        r.raise_for_status()
-        check_bundle = r.json()[0]
+        check_bundle = self.get_collectd_check_bundle(target)
         data = get_df_graph_data(check_bundle, mount_dir)
         return self.create("graph", data) if data else None
-
-    def get_collectd_check_bundle(self, target):
-        """Get a ``collectd`` check bundle for ``target``.
-
-        :param str target: The target to filter the check bundle.
-        :rtype: :py:class:`dict`
-
-        The *first* ``collectd`` check bundle for ``target`` will be returned.  A given ``target`` should not have
-        more than one ``collectd`` check bundle at any given moment.
-
-        """
-        r = self.get("check_bundle", {"f_target": target, "f_type": "collectd"})
-        r.raise_for_status()
-        check_bundle = r.json()[0]
-        return check_bundle
 
     def create_collectd_graphs(self, target, interface_names=None, mount_dirs=None):
         """Create several graphs from a ``collectd`` check bundle.

--- a/circonus/client.py
+++ b/circonus/client.py
@@ -260,10 +260,11 @@ class CirconusClient(object):
         data = get_memory_graph_data(check_bundle)
         return self.create("graph", data) if data else None
 
-    def create_collectd_interface_graph(self, target):
+    def create_collectd_interface_graph(self, target, interface_name="eth0"):
         """Create an interface graph from a ``collectd`` check bundle for ``target``.
 
         :param str target: The target of the check bundle to filter for.
+        :param str interface_name: (optional) The interface name, e.g., "eth0".
         :rtype: :class:`requests.Response` or :py:const:`None`
 
         ``target`` is used to filter ``collectd`` check bundles.
@@ -274,7 +275,7 @@ class CirconusClient(object):
         r = self.get("check_bundle", {"f_target": target, "f_type": "collectd"})
         r.raise_for_status()
         check_bundle = r.json()[0]
-        data = get_interface_graph_data(check_bundle)
+        data = get_interface_graph_data(check_bundle, interface_name)
         return self.create("graph", data) if data else None
 
     def create_collectd_df_graph(self, target, mount_dir):

--- a/circonus/collectd/graph.py
+++ b/circonus/collectd/graph.py
@@ -1,0 +1,33 @@
+"""
+
+circonus.collectd.graph
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Create graph data for several ``collectd`` graphs.
+
+"""
+
+from circonus.collectd.cpu import get_cpu_graph_data
+from circonus.collectd.df import get_df_graph_data
+from circonus.collectd.memory import get_memory_graph_data
+from circonus.collectd.interface import get_interface_graph_data
+
+
+def get_collectd_graph_data(check_bundle, interface_names, mount_dirs):
+    """Get ``collectd`` graph data for ``check_bundle``.
+
+    :param dict check_bundle: The check bundle to get graph data from.
+    :param list interface_names: The interface names to get data for.
+    :param list mount_dirs: The mount directories to get data for.
+    :rtype: :py:class:`list`
+
+    The returned list will only contain valid graph data.
+
+    """
+    graph_data = [
+        get_cpu_graph_data(check_bundle),
+        get_memory_graph_data(check_bundle)
+    ]
+    graph_data.extend([get_interface_graph_data(check_bundle, i) for i in interface_names])
+    graph_data.extend([get_df_graph_data(check_bundle, d) for d in mount_dirs])
+    return [d for d in graph_data if d]

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -58,6 +58,9 @@ Modules
 .. automodule:: circonus.collectd.df
    :members:
 
+.. automodule:: circonus.collectd.graph
+   :members:
+
 .. automodule:: circonus.collectd.memory
    :members:
 

--- a/test_circonus.py
+++ b/test_circonus.py
@@ -343,7 +343,11 @@ class CirconusClientTestCase(unittest.TestCase):
             self.assertIsNotNone(a.stop)
             create_patch.assert_called()
 
+    @responses.activate
     def test_create_annotation(self):
+        responses.add(responses.POST, get_api_url(Annotation.RESOURCE_PATH),
+                      body=json.dumps({"message": "test", "code": "test"}), status=403,
+                      content_type="application/json")
         with self.assertRaises(HTTPError):
             self.c.create_annotation("title", "category")
 


### PR DESCRIPTION
- Add method to create `collectd` graphs for a target with a single call.
- Update `cpu` module API to act more like the other `collectd` plugin modules.
- Make the `log_http_error` decorator raise HTTPError.