### PR TITLE
Change client graph interface to take check bundle

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,18 @@
 Release History
 ---------------
 
+0.0.21 (2015-01-29)
++++++++++++++++++++
+
+**Improvements**
+
+- Change the ``collectd`` client interface to take an explicit check bundle to
+  create graphs from rather than naïvely using the *first* ``collectd`` check
+  bundle found for ``target``.
+
+- Refactor the ``datetime_to_int`` method from ``Annotation`` to be a function
+  in ``util``.
+
 0.0.20 (2015-01-28)
 +++++++++++++++++++
 

--- a/circonus/__init__.py
+++ b/circonus/__init__.py
@@ -1,5 +1,5 @@
 __title__ = "circonus"
-__version__ = "0.0.20"
+__version__ = "0.0.21"
 
 from logging import NullHandler
 

--- a/circonus/annotation.py
+++ b/circonus/annotation.py
@@ -5,9 +5,10 @@ circonus.annotation
 
 """
 
-from calendar import timegm
 from datetime import datetime
 from functools import wraps
+
+from circonus.util import datetime_to_int
 
 
 class Annotation(object):
@@ -27,20 +28,6 @@ class Annotation(object):
     """
 
     RESOURCE_PATH = "annotation"
-
-    @staticmethod
-    def datetime_to_int(dt):
-        """Convert date and time to seconds since the epoch.
-
-        :param datetime.datetime dt: The date and time to convert.
-        :rtype: :py:class:`int`
-
-        ``dt`` is expected to have been created for the UTC date and time, e.g., with
-        :py:meth:`datetime.datetime.utcnow`.  It is converted to seconds since the epoch with
-        :py:func:`calendar.timegm` to respect UTC.
-
-        """
-        return int(timegm(dt.timetuple()))
 
     def __init__(self, client, title, category, description="", rel_metrics=None):
         self.client = client
@@ -78,8 +65,8 @@ class Annotation(object):
         data = {
             "title": self.title,
             "category": self.category,
-            "start": self.datetime_to_int(self.start),
-            "stop": self.datetime_to_int(self.stop),
+            "start": datetime_to_int(self.start),
+            "stop": datetime_to_int(self.stop),
             "description": self.description,
             "rel_metrics": self.rel_metrics
         }

--- a/circonus/client.py
+++ b/circonus/client.py
@@ -235,19 +235,6 @@ class CirconusClient(object):
         a.create()
         return a
 
-    def get_collectd_check_bundle(self, target):
-        """Get a ``collectd`` check bundle for ``target``.
-
-        :param str target: The target to filter the check bundle.
-        :rtype: :py:class:`dict`
-
-        The *first* ``collectd`` check bundle for ``target`` will be returned.  A given ``target`` should not have
-        more than one ``collectd`` check bundle at any given moment.
-
-        """
-        r = self.get("check_bundle", {"f_target": target, "f_type": "collectd"})
-        check_bundle = r.json()[0]
-        return check_bundle
 
     def create_collectd_cpu_graph(self, check_bundle, title=None):
         """Create a CPU graph from the ``collectd`` ``check_bundle``.

--- a/circonus/client.py
+++ b/circonus/client.py
@@ -262,19 +262,18 @@ class CirconusClient(object):
         data = get_cpu_graph_data(check_bundle, title)
         return self.create("graph", data) if data else None
 
-    def create_collectd_memory_graph(self, target, title=None):
-        """Create a memory graph from a ``collectd`` check bundle for ``target``.
+    def create_collectd_memory_graph(self, check_bundle, title=None):
+        """Create a memory graph from the ``collectd`` ``check_bundle``.
 
-        :param str target: The target of the check bundle to filter for.
+        :param dict check_bundle: The check bundle to create a graph for.
         :param str title: (optional) The title to use for the graph.
         :rtype: :class:`requests.Response` or :py:const:`None`
 
         ``target`` is used to filter ``collectd`` check bundles.
 
-        :py:const:`None` is returned if no data to create the graph could be found for ``target``.
+        :py:const:`None` is returned if no data to create the graph could be found in ``check_bundle``.
 
         """
-        check_bundle = self.get_collectd_check_bundle(target)
         data = get_memory_graph_data(check_bundle, title)
         return self.create("graph", data) if data else None
 

--- a/circonus/client.py
+++ b/circonus/client.py
@@ -269,8 +269,6 @@ class CirconusClient(object):
         :param str title: (optional) The title to use for the graph.
         :rtype: :class:`requests.Response` or :py:const:`None`
 
-        ``target`` is used to filter ``collectd`` check bundles.
-
         :py:const:`None` is returned if no data to create the graph could be found in ``check_bundle``.
 
         """

--- a/circonus/client.py
+++ b/circonus/client.py
@@ -235,7 +235,6 @@ class CirconusClient(object):
         a.create()
         return a
 
-
     def create_collectd_cpu_graph(self, check_bundle, title=None):
         """Create a CPU graph from the ``collectd`` ``check_bundle``.
 

--- a/circonus/client.py
+++ b/circonus/client.py
@@ -275,20 +275,17 @@ class CirconusClient(object):
         data = get_memory_graph_data(check_bundle, title)
         return self.create("graph", data) if data else None
 
-    def create_collectd_interface_graph(self, target, interface_name="eth0", title=None):
-        """Create an interface graph from a ``collectd`` check bundle for ``target``.
+    def create_collectd_interface_graph(self, check_bundle, interface_name="eth0", title=None):
+        """Create an interface graph from the ``collectd`` ``check_bundle``.
 
-        :param str target: The target of the check bundle to filter for.
+        :param dict check_bundle: The check bundle to create a graph for.
         :param str interface_name: (optional) The interface name, e.g., "eth0".
         :param str title: (optional) The title to use for the graph.
         :rtype: :class:`requests.Response` or :py:const:`None`
 
-        ``target`` is used to filter ``collectd`` check bundles.
-
-        :py:const:`None` is returned if no data to create the graph could be found for ``target``.
+        :py:const:`None` is returned if no data to create the graph could be found in ``check_bundle``.
 
         """
-        check_bundle = self.get_collectd_check_bundle(target)
         data = get_interface_graph_data(check_bundle, interface_name, title)
         return self.create("graph", data) if data else None
 

--- a/circonus/client.py
+++ b/circonus/client.py
@@ -289,20 +289,17 @@ class CirconusClient(object):
         data = get_interface_graph_data(check_bundle, interface_name, title)
         return self.create("graph", data) if data else None
 
-    def create_collectd_df_graph(self, target, mount_dir, title=None):
-        """Create a disk free graph from a ``collectd`` check bundle for ``mount_dir`` on ``target``.
+    def create_collectd_df_graph(self, check_bundle, mount_dir, title=None):
+        """Create a disk free graph from the ``collectd`` ``check_bundle`` for ``mount_dir`` on ``target``.
 
-        :param str target: The target of the check bundle to filter for.
+        :param dict check_bundle: The check bundle to create a graph for.
         :param str mount_dir: The mount directory to create the graph for.
         :param str title: (optional) The title to use for the graph.
         :rtype: :class:`requests.Response` or :py:const:`None`
 
-        ``target`` is used to filter ``collectd`` check bundles.
-
-        :py:const:`None` is returned if no data to create the graph could be found for ``target``.
+        :py:const:`None` is returned if no data to create the graph could be found in ``check_bundle``.
 
         """
-        check_bundle = self.get_collectd_check_bundle(target)
         data = get_df_graph_data(check_bundle, mount_dir, title)
         return self.create("graph", data) if data else None
 

--- a/circonus/client.py
+++ b/circonus/client.py
@@ -252,7 +252,7 @@ class CirconusClient(object):
     def create_collectd_cpu_graph(self, check_bundle, title=None):
         """Create a CPU graph from the ``collectd`` ``check_bundle``.
 
-        :param dict target: The check bundle to create a graph for.
+        :param dict check_bundle: The check bundle to create a graph for.
         :param str title: (optional) The title to use for the graph.
         :rtype: :class:`requests.Response` or :py:const:`None`
 

--- a/circonus/client.py
+++ b/circonus/client.py
@@ -249,19 +249,16 @@ class CirconusClient(object):
         check_bundle = r.json()[0]
         return check_bundle
 
-    def create_collectd_cpu_graph(self, target, title=None):
-        """Create a CPU graph from a ``collectd`` check bundle for ``target``.
+    def create_collectd_cpu_graph(self, check_bundle, title=None):
+        """Create a CPU graph from the ``collectd`` ``check_bundle``.
 
-        :param str target: The target of the check bundle to filter for.
+        :param dict target: The check bundle to create a graph for.
         :param str title: (optional) The title to use for the graph.
         :rtype: :class:`requests.Response` or :py:const:`None`
 
-        ``target`` is used to filter ``collectd`` check bundles.
-
-        :py:const:`None` is returned if no data to create the graph could be found for ``target``.
+        :py:const:`None` is returned if no data to create the graph could be found in ``check_bundle``.
 
         """
-        check_bundle = self.get_collectd_check_bundle(target)
         data = get_cpu_graph_data(check_bundle, title)
         return self.create("graph", data) if data else None
 

--- a/circonus/client.py
+++ b/circonus/client.py
@@ -303,19 +303,14 @@ class CirconusClient(object):
         data = get_df_graph_data(check_bundle, mount_dir, title)
         return self.create("graph", data) if data else None
 
-    def create_collectd_graphs(self, target, interface_names=None, mount_dirs=None, titles=None):
-        """Create several graphs from a ``collectd`` check bundle.
+    def create_collectd_graphs(self, check_bundle, interface_names=None, mount_dirs=None, titles=None):
+        """Create several graphs from the ``collectd`` ``check_bundle``.
 
-        :param str target: The target of the check bundle to filter for.
+        :param dict check_bundle: The check bundle to create graphs for.
         :param list interface_name: (optional) The interface names to create ``interface`` graphs for, e.g., ``["eth0"]``.
         :param list mount_dirs: (optional) The mount directories to create ``df`` graphs for, e.g., ``["/root", "/mnt"]``.
         :param dict titles: (optional) The titles to use for each graph.
         :rtype: (:py:class:`bool`, :py:class:`list`)
-
-        ``target`` is used to filter ``collectd`` check bundles.
-
-        Only the first ``collectd`` check bundle will be used as no ``target`` should have more than a single
-        ``collectd`` check bundle at once.
 
         ``mount_dirs`` should be a :py:class:`list` of directories where devices are mounted.  ``df`` graphs will be
         created for each.
@@ -343,7 +338,6 @@ class CirconusClient(object):
 
         responses = []
         try:
-            check_bundle = self.get_collectd_check_bundle(target)
             graph_data = get_collectd_graph_data(check_bundle, interface_names, mount_dirs, titles=titles)
             for d in graph_data:
                 responses.append(self.create("graph", d))

--- a/circonus/util.py
+++ b/circonus/util.py
@@ -8,9 +8,24 @@ Utility functions that other modules depend upon.
 """
 
 
+from calendar import timegm
 from posixpath import sep as pathsep
 
 from colour import Color
+
+
+def datetime_to_int(dt):
+    """Convert date and time to seconds since the epoch.
+
+    :param datetime.datetime dt: The date and time to convert.
+    :rtype: :py:class:`int`
+
+    ``dt`` is expected to have been created for the UTC date and time, e.g., with
+    :py:meth:`datetime.datetime.utcnow`.  It is converted to seconds since the epoch with
+    :py:func:`calendar.timegm` to respect UTC.
+
+    """
+    return int(timegm(dt.timetuple()))
 
 
 def get_check_id_from_cid(cid):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with codecs.open("HISTORY.rst", "r", "utf-8") as f:
 
 setup(
     name="circonus",
-    version="0.0.20",
+    version="0.0.21",
     description="Interact with the Circonus REST API.",
     long_description=readme + "\n\n" + history,
     author="Monetate Inc.",

--- a/test_circonus.py
+++ b/test_circonus.py
@@ -559,33 +559,26 @@ class CirconusClientTestCase(unittest.TestCase):
             actual = json.loads(post_patch.call_args[-1]["data"])
             self.assertEqual(title, actual["title"])
 
-    @responses.activate
     def test_create_collectd_memory_graph_no_memory_metrics(self):
         target = "10.0.0.1"
         cb = {"target": target, "type": "collectd"}
-        responses.add(responses.GET, get_api_url("check_bundle"), body=json.dumps([cb]), status=200,
-                      content_type="application/json")
         with patch("circonus.client.requests.post") as post_patch:
-            self.assertIsNone(self.c.create_collectd_memory_graph(target))
+            self.assertIsNone(self.c.create_collectd_memory_graph(cb))
             post_patch.assert_not_called()
 
-    @responses.activate
     def test_create_collectd_memory_graph_too_few_metrics(self):
         target = "10.0.0.1"
         cb = {"_checks": ["/check_bundle/12345"],
               "target": target,
               "type": "collectd",
               "metrics": [{"status": "active", "type": "numeric", "name": "memory`memory`cached"}]}
-        responses.add(responses.GET, get_api_url("check_bundle"), body=json.dumps([cb]), status=200,
-                      content_type="application/json")
         expected = {"min_left_y": 0, "datapoints": [], "tags": ["telemetry:collectd"], "min_right_y": 0, "title": "10.0.0.1 memory"}
         with patch("circonus.client.requests.post") as post_patch:
-            self.assertIsNotNone(self.c.create_collectd_memory_graph(target))
+            self.assertIsNotNone(self.c.create_collectd_memory_graph(cb))
             post_patch.assert_called()
             actual = json.loads(post_patch.call_args[-1]["data"])
             self.assertEqual(expected, actual)
 
-    @responses.activate
     def test_create_collectd_memory_graph(self):
         target = "10.0.0.1"
         cb = {"_checks": ["/check_bundle/12345"],
@@ -595,8 +588,6 @@ class CirconusClientTestCase(unittest.TestCase):
                           {"status": "active", "type": "numeric", "name": "memory`memory`free"},
                           {"status": "active", "type": "numeric", "name": "memory`memory`used"},
                           {"status": "active", "type": "numeric", "name": "memory`memory`buffered"}]}
-        responses.add(responses.GET, get_api_url("check_bundle"), body=json.dumps([cb]), status=200,
-                      content_type="application/json")
         expected = {"min_left_y": 0,
                     "datapoints": [{"color": "#ff0000", "legend_formula": None, "derive": "gauge", "metric_type": "numeric", "alpha": None, "stack": 0, "name": "memory`memory`used", "data_formula": None, "metric_name": "memory`memory`used", "check_id": 12345, "hidden": False, "axis": "l"},
                                    {"color": "#d58e00", "legend_formula": None, "derive": "gauge", "metric_type": "numeric", "alpha": None, "stack": 0, "name": "memory`memory`buffered", "data_formula": None,"metric_name": "memory`memory`buffered", "check_id": 12345, "hidden": False, "axis": "l"},
@@ -606,13 +597,13 @@ class CirconusClientTestCase(unittest.TestCase):
                     "min_right_y": 0,
                     "title": "10.0.0.1 memory"}
         with patch("circonus.client.requests.post") as post_patch:
-            self.assertIsNotNone(self.c.create_collectd_memory_graph(target))
+            self.assertIsNotNone(self.c.create_collectd_memory_graph(cb))
             post_patch.assert_called()
             actual = json.loads(post_patch.call_args[-1]["data"])
             self.assertEqual(expected, actual)
 
             title = "test title"
-            self.assertIsNotNone(self.c.create_collectd_memory_graph(target, title))
+            self.assertIsNotNone(self.c.create_collectd_memory_graph(cb, title))
             actual = json.loads(post_patch.call_args[-1]["data"])
             self.assertEqual(title, actual["title"])
 

--- a/test_circonus.py
+++ b/test_circonus.py
@@ -607,7 +607,6 @@ class CirconusClientTestCase(unittest.TestCase):
             actual = json.loads(post_patch.call_args[-1]["data"])
             self.assertEqual(title, actual["title"])
 
-    @responses.activate
     def test_create_collectd_interface_graph(self):
         target = "10.0.0.1"
         cb = {"_checks": ["/check_bundle/12345"],
@@ -617,8 +616,6 @@ class CirconusClientTestCase(unittest.TestCase):
                           {"name": "interface`eth0`if_octets`tx", "status": "active", "type": "numeric"},
                           {"name": "interface`eth0`if_errors`rx", "status": "active", "type": "numeric"},
                           {"name": "interface`eth0`if_errors`tx", "status": "active", "type": "numeric"}]}
-        responses.add(responses.GET, get_api_url("check_bundle"), body=json.dumps([cb]), status=200,
-                      content_type="application/json")
         expected = {"title": "10.0.0.1 interface eth0 bit/s",
                     "datapoints": [
                         {"derive": "counter", "name": "interface`eth0`if_octets`tx", "color": "#ff0000", "legend_formula":None, "check_id": 12345, "data_formula": "=8*VAL", "metric_type": "numeric", "alpha": None, "hidden": False, "axis": "l", "stack": None, "metric_name": "interface`eth0`if_octets`tx"},
@@ -627,14 +624,14 @@ class CirconusClientTestCase(unittest.TestCase):
                         {"derive": "counter", "name": "interface`eth0`if_errors`rx", "color": "#008000", "legend_formula": None, "check_id": 12345, "data_formula": None, "metric_type": "numeric", "alpha": None, "hidden": False, "axis": "r", "stack": None, "metric_name": "interface`eth0`if_errors`rx"}],
                     "tags": ["telemetry:collectd"]}
         with patch("circonus.client.requests.post") as post_patch:
-            self.assertIsNotNone(self.c.create_collectd_interface_graph(target))
+            self.assertIsNotNone(self.c.create_collectd_interface_graph(cb))
             post_patch.assert_called()
             actual = json.loads(post_patch.call_args[-1]["data"])
             self.assertEqual(expected, actual)
 
             title = "test title"
             expected = title + " eth0 bit/s"
-            self.assertIsNotNone(self.c.create_collectd_interface_graph(target, title=title))
+            self.assertIsNotNone(self.c.create_collectd_interface_graph(cb, title=title))
             post_patch.assert_called()
             actual = json.loads(post_patch.call_args[-1]["data"])
             self.assertEqual(expected, actual["title"])

--- a/test_circonus.py
+++ b/test_circonus.py
@@ -636,7 +636,6 @@ class CirconusClientTestCase(unittest.TestCase):
             actual = json.loads(post_patch.call_args[-1]["data"])
             self.assertEqual(expected, actual["title"])
 
-    @responses.activate
     def test_create_collectd_df_graph(self):
         target = "10.0.0.1"
         cb = {"_checks": ["/check_bundle/12345"],
@@ -649,8 +648,6 @@ class CirconusClientTestCase(unittest.TestCase):
                           {"name": "df`mnt-solr-home`df_complex`reserved", "status": "active", "type": "numeric"},
                           {"name": "df`mnt-solr-home`df_complex`used", "status": "active", "type": "numeric"},
                           {"name": "df`mnt`df_complex`free", "status": "active", "type": "numeric"}]}
-        responses.add(responses.GET, get_api_url("check_bundle"), body=json.dumps([cb]), status=200,
-                      content_type="application/json")
         expected = {"min_right_y": 0,
                     "title": "10.0.0.1 df /mnt/mysql",
                     "min_left_y": 0,
@@ -659,7 +656,7 @@ class CirconusClientTestCase(unittest.TestCase):
                                    {"derive": "gauge", "name": "df`mnt-mysql`df_complex`used", "color": "#bfbf00", "legend_formula":None, "check_id": 12345, "data_formula": None, "metric_type": "numeric", "alpha": None, "hidden": False, "axis":"l", "stack": 0, "metric_name": "df`mnt-mysql`df_complex`used"},
                                    {"derive": "gauge", "name": "df`mnt-mysql`df_complex`free", "color": "#008000", "legend_formula": None, "check_id": 12345, "data_formula": None, "metric_type": "numeric", "alpha": None, "hidden": False, "axis": "l", "stack": 0, "metric_name": "df`mnt-mysql`df_complex`free"}]}
         with patch("circonus.client.requests.post") as post_patch:
-            self.assertIsNotNone(self.c.create_collectd_df_graph(target, "/mnt/mysql"))
+            self.assertIsNotNone(self.c.create_collectd_df_graph(cb, "/mnt/mysql"))
             post_patch.assert_called()
             actual = json.loads(post_patch.call_args[-1]["data"])
             self.assertEqual(expected, actual)
@@ -667,7 +664,7 @@ class CirconusClientTestCase(unittest.TestCase):
             title = "test title"
             mount_dir = "/mnt/mysql"
             expected = "%s %s" % (title, mount_dir)
-            self.assertIsNotNone(self.c.create_collectd_df_graph(target, mount_dir, title))
+            self.assertIsNotNone(self.c.create_collectd_df_graph(cb, mount_dir, title))
             post_patch.assert_called()
             actual = json.loads(post_patch.call_args[-1]["data"])
             self.assertEqual(expected, actual["title"])

--- a/test_circonus.py
+++ b/test_circonus.py
@@ -755,8 +755,8 @@ class AnnotationTestCase(unittest.TestCase):
             expected_data = {
                 "title": a.title,
                 "category": a.category,
-                "start": a.datetime_to_int(a.start),
-                "stop": a.datetime_to_int(a.stop),
+                "start": util.datetime_to_int(a.start),
+                "stop": util.datetime_to_int(a.stop),
                 "description": a.description,
                 "rel_metrics": a.rel_metrics
             }

--- a/test_circonus.py
+++ b/test_circonus.py
@@ -679,23 +679,6 @@ class CirconusClientTestCase(unittest.TestCase):
             self.c.create_collectd_graphs(check_bundle)
             self.assertEqual("collectd graphs could not be created: %s", log_patch.error.call_args[0][0])
 
-    @responses.activate
-    def test_get_collectd_check_bundle_raises_http_error(self):
-        responses.add(responses.GET, get_api_url("check_bundle"),
-                      body=json.dumps({"message": "test", "code": "test", "explanation": "test"}),
-                      status=500,
-                      content_type="application/json")
-        with self.assertRaises(HTTPError):
-            self.c.get_collectd_check_bundle("10.0.0.1")
-
-    @responses.activate
-    def test_get_collectd_check_bundle(self):
-        target = "10.0.0.1"
-        responses.add(responses.GET, get_api_url("check_bundle"), body=json.dumps([check_bundle]), status=200,
-                      content_type="application/json")
-        cb = self.c.get_collectd_check_bundle(target)
-        self.assertIsInstance(cb, types.DictType)
-
     def test_create_collectd_graphs_no_metrics(self):
         target = "10.0.0.1"
         cb = {"_checks": ["/check_bundle/12345"],


### PR DESCRIPTION
Rather than a target.  Explicit is better than naively taking the first check bundle for a target.