### PR TITLE
collectd - Update df metric re to select complex.

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,14 @@
 Release History
 ---------------
 
+0.0.22 (2015-02-14)
++++++++++++++++++++
+
+**Bug fixes**
+
+- Avoid selecting ``df`` metrics other than ``df_complex`` when creating disk
+  free graphs.
+
 0.0.21 (2015-01-29)
 +++++++++++++++++++
 

--- a/circonus/__init__.py
+++ b/circonus/__init__.py
@@ -1,5 +1,5 @@
 __title__ = "circonus"
-__version__ = "0.0.21"
+__version__ = "0.0.22"
 
 from logging import NullHandler
 

--- a/circonus/collectd/df.py
+++ b/circonus/collectd/df.py
@@ -28,8 +28,9 @@ This list is used to filter and sort metrics in preparation for creating a graph
 
 DF_METRIC_RE = re.compile(r"""
 ^df                             # Starts with "df"
-`.*`                            # Anything in between
-({}|{}|{})$                     # Ends with defined suffix
+`.*                             # Has a mount directory
+`df_complex                     # Is a complex metric
+`({}|{}|{})$                    # Ends with defined suffix
 """.format(*DF_METRIC_SUFFIXES), re.X)
 """A compiled regular expression which matches ``collectd`` metrics."""
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with codecs.open("HISTORY.rst", "r", "utf-8") as f:
 
 setup(
     name="circonus",
-    version="0.0.21",
+    version="0.0.22",
     description="Interact with the Circonus REST API.",
     long_description=readme + "\n\n" + history,
     author="Monetate Inc.",

--- a/test_circonus.py
+++ b/test_circonus.py
@@ -58,6 +58,15 @@ check_bundle = {"_checks": ["/check/123456"],
                             {"name": "df`mnt-mysql`df_complex`reserved",
                              "status": "active",
                              "type": "numeric"},
+                            {"name": "df`mnt-mysql`percent_bytes`used",
+                             "status": "active",
+                             "type": "numeric"},
+                            {"name": "df`mnt-mysql`percent_bytes`free",
+                             "status": "active",
+                             "type": "numeric"},
+                            {"name": "df`mnt-mysql`percent_bytes`reserved",
+                             "status": "active",
+                             "type": "numeric"},
                             {"name": "df`mnt-solr-home`df_complex`free",
                              "status": "active",
                              "type": "numeric"},
@@ -1340,8 +1349,9 @@ class CollectdDfTestCase(unittest.TestCase):
         self.assertItemsEqual(expected, actual)
 
         expected = [m for m in check_bundle["metrics"] if m["name"].startswith("df`")]
-        expected = [m for m in expected if "`mnt-mysql`" in m["name"]]
+        expected = [m for m in expected if "`mnt-mysql`" in m["name"] and "`df_complex" in m["name"]]
         actual = df.get_df_metrics(check_bundle["metrics"], "mnt/mysql")
+        self.assertEqual(3, len(actual))
         self.assertItemsEqual(expected, actual)
         actual = df.get_df_metrics(check_bundle["metrics"], "/mnt/mysql")
         self.assertItemsEqual(expected, actual)


### PR DESCRIPTION
Avoid selecting `df` metrics other than `df_complex` when creating disk free graphs.