### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,7 +3,7 @@ Circonus
 
 A Python module for interacting with the `Circonus`_ `REST API`_.
 
-.. image:: https://pypip.in/v/circonus/badge.png?style=flat
+.. image:: https://img.shields.io/pypi/v/circonus.svg?style=flat
    :target: https://pypi.python.org/pypi/circonus
    :alt: Latest release
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20circonus))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `circonus`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.